### PR TITLE
Fixed security issues and updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ I know I will. This tool tries to automate that process as much as possible.
 dotnet tool install -g FluentAssertionsMigrator
 ```
 
+### Building the Tool yourself
+
+```bash
+cd C:\...\fluentassertions-migrator\src\
+dotnet pack
+dotnet tool install -g FluentAssertionsMigrator
+```
+
 ## Usage
 
 **Make a backup of your solution (or use version control like a sane person) before you run this tool**

--- a/src/FluentAssertionsMigrator/FluentAssertionsMigrator.csproj
+++ b/src/FluentAssertionsMigrator/FluentAssertionsMigrator.csproj
@@ -22,11 +22,12 @@
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
-      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.12.0" />
-      <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.12.0" />
-      <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.12.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.14.0" />
+      <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0"/>
       <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.1" />
+      <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.8" ExcludeAssets="runtime" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I used your tool to remove FluentAssertions in our project. However I had to build the Project myself and got stuck with security problems.
I've updated the packages and hat to put in a temporal workaround for Microsoft.Build.Tasks.Core:
      <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.8" ExcludeAssets="runtime" />

Updated the readme on how to build it on your own